### PR TITLE
Refactor delaylines into class

### DIFF
--- a/Delayyyyyy.jucer
+++ b/Delayyyyyy.jucer
@@ -4,6 +4,8 @@
               addUsingNamespaceToJuceHeader="0" displaySplashScreen="1" jucerFormatVersion="1">
   <MAINGROUP id="r6S8xT" name="Delayyyyyy">
     <GROUP id="{3C0E9CA2-6AD6-8AA2-BD57-778E761B1EAE}" name="Source">
+      <FILE id="HXOgoJ" name="DelayBuffer.h" compile="0" resource="0" file="Source/DelayBuffer.h"/>
+      <FILE id="kdrlYB" name="DelayBuffer.cpp" compile="1" resource="0" file="Source/DelayBuffer.cpp"/>
       <FILE id="Rl6pfU" name="PluginProcessor.cpp" compile="1" resource="0"
             file="Source/PluginProcessor.cpp"/>
       <FILE id="I97Vvs" name="PluginProcessor.h" compile="0" resource="0"

--- a/Source/DelayBuffer.cpp
+++ b/Source/DelayBuffer.cpp
@@ -1,0 +1,37 @@
+
+#include "DelayBuffer.h"
+
+DelayBuffer::DelayBuffer() {
+    delayLine.clear();
+    delayReadPosition = 0;
+    delayWritePosition = 0;
+}
+
+DelayBuffer::~DelayBuffer()
+{
+}
+
+void DelayBuffer::setDelayLineParameters(int numChannels, int numSamples) {
+    delayLine.setSize(numChannels, numSamples);
+    delayLine.clear();
+}
+
+float* DelayBuffer::getDelayLineWritePointer(int channel) {
+    return delayLine.getWritePointer(channel);
+}
+
+void DelayBuffer::setDelayReadPosition(int delayReadPosition) {
+    this->delayReadPosition = delayReadPosition;
+}
+
+int DelayBuffer::getDelayReadPosition() {
+    return delayReadPosition;
+}
+
+void DelayBuffer::setDelayWritePosition(int delayWritePosition) {
+    this->delayWritePosition = delayWritePosition;
+}
+
+int DelayBuffer::getDelayWritePosition() {
+    return delayWritePosition;
+}

--- a/Source/DelayBuffer.h
+++ b/Source/DelayBuffer.h
@@ -1,0 +1,24 @@
+
+#pragma once
+
+#include <JuceHeader.h>
+
+class DelayBuffer {
+public:
+    DelayBuffer();
+    ~DelayBuffer();
+
+    void setDelayLineParameters(int numChannels, int numSamples);
+    float *getDelayLineWritePointer(int channel);
+
+    void setDelayReadPosition(int delayReadPosition);
+    int getDelayReadPosition();
+
+    void setDelayWritePosition(int delayWritePosition);
+    int getDelayWritePosition();
+
+private:
+    juce::AudioBuffer<float> delayLine;
+    int delayReadPosition;
+    int delayWritePosition;
+};

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -93,8 +93,6 @@ void DelayyyyyyAudioProcessor::changeProgramName (int index, const juce::String&
 //TODO: Slightly misleading name. This sets only the delay buffers, not all params
 void DelayyyyyyAudioProcessor::setDelayParams() {
     for (int i = bufferAmount - 1; i >= 0; i = i - 1) {
-        //TODO: Instead of creating new buffers every time, perhaps existing ones could be re-used
-        // That way earlier echos would still remain. Not sure if this that important though
         DelayBuffer newDelayBuffer;
 
         //TODO: This doesn't really have to be this big for all of the buffers

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <JuceHeader.h>
+#include "DelayBuffer.h"
 
 //==============================================================================
 /**
@@ -61,12 +62,7 @@ public:
 
 private:
     //==============================================================================
-
-    //TODO: instead of having these in three separate vectors, they could be refactored into one class
-    // This way only one vector would be needed to avoid them getting mismatched
-    std::vector<juce::AudioBuffer<float>> delayLines;
-    std::vector<int> delayReadPositions;
-    std::vector<int> delayWritePositions;
+    std::vector<DelayBuffer> delayBuffers;
 
     double currentSampleRate = 44100;
 


### PR DESCRIPTION
Instead of having information about one delay buffer in three separate vectors, create a class and use one vector to store that. Much better.

Also removed one TODO that I don't see a point in implementing.