### PR TITLE
Optimize buffers

### DIFF
--- a/Source/DelayBuffer.cpp
+++ b/Source/DelayBuffer.cpp
@@ -3,6 +3,7 @@
 
 DelayBuffer::DelayBuffer() {
     delayLine.clear();
+    delayLineSize = 0;
     delayReadPosition = 0;
     delayWritePosition = 0;
 }
@@ -14,10 +15,15 @@ DelayBuffer::~DelayBuffer()
 void DelayBuffer::setDelayLineParameters(int numChannels, int numSamples) {
     delayLine.setSize(numChannels, numSamples);
     delayLine.clear();
+    delayLineSize = numSamples;
 }
 
 float* DelayBuffer::getDelayLineWritePointer(int channel) {
     return delayLine.getWritePointer(channel);
+}
+
+int DelayBuffer::getDelayLineSize() {
+    return delayLineSize;
 }
 
 void DelayBuffer::setDelayReadPosition(int delayReadPosition) {

--- a/Source/DelayBuffer.h
+++ b/Source/DelayBuffer.h
@@ -10,6 +10,7 @@ public:
 
     void setDelayLineParameters(int numChannels, int numSamples);
     float *getDelayLineWritePointer(int channel);
+    int getDelayLineSize();
 
     void setDelayReadPosition(int delayReadPosition);
     int getDelayReadPosition();
@@ -19,6 +20,7 @@ public:
 
 private:
     juce::AudioBuffer<float> delayLine;
+    int delayLineSize;
     int delayReadPosition;
     int delayWritePosition;
 };

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -95,11 +95,11 @@ void DelayyyyyyAudioProcessor::setDelayParams() {
     for (int i = bufferAmount - 1; i >= 0; i = i - 1) {
         DelayBuffer newDelayBuffer;
 
-        //TODO: This doesn't really have to be this big for all of the buffers
+        //TODO: Delay buffer doesn't really have to be this big for all of the buffers
         // The earlier the buffer plays, the shorter this can be (saving some memory)
-        int delayInSamples = (int)(delayLength * currentSampleRate) / juce::jmax(1, 2 * i);
-
         newDelayBuffer.setDelayLineParameters(getTotalNumInputChannels(), delayBufferLength);
+
+        int delayInSamples = (int)(delayLength * currentSampleRate) / juce::jmax(1, 2 * i);
         newDelayBuffer.setDelayWritePosition(delayInSamples);
 
         delayBuffers.insert(delayBuffers.begin(), newDelayBuffer);
@@ -114,9 +114,8 @@ void DelayyyyyyAudioProcessor::prepareToPlay (double sampleRate, int samplesPerB
     // Use this method as the place to do any pre-playback
     // initialisation that you need..
     
-    //TODO: 10 seconds is a bit much, considering the fact the maximum unsynced delay time is 5 seconds
-    //TODO: instead of magic number 10, use some variable
-    delayBufferLength = (int)(10 * sampleRate);
+
+    delayBufferLength = (int)(BUFFER_MAX_LEN_SEC * sampleRate);
     currentSampleRate = sampleRate;
 
     setDelayParams();

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -11,6 +11,10 @@
 #include <JuceHeader.h>
 #include "DelayBuffer.h"
 
+//TODO: 10 seconds is a bit much, considering the fact the maximum unsynced delay time is 5 seconds (5 seconds defined in slider
+// should consider using a define for it as well)
+#define BUFFER_MAX_LEN_SEC 10
+
 //==============================================================================
 /**
 */
@@ -66,7 +70,7 @@ private:
 
     double currentSampleRate = 44100;
 
-    int delayBufferLength = (int)currentSampleRate * 10;
+    int delayBufferLength = (int)currentSampleRate * BUFFER_MAX_LEN_SEC;
     //TODO: Buffer amount and echo amount are used to describe this same thing, make it more consistent
     int bufferAmount = 3;
     float delayLength = 1.0f;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -12,7 +12,7 @@
 #include "DelayBuffer.h"
 
 //TODO: 10 seconds is a bit much, considering the fact the maximum unsynced delay time is 5 seconds (5 seconds defined in slider
-// should consider using a define for it as well)
+// should consider using a define for it as well). Perhaps this should  be variable, depending on the current maximum delay size?
 #define BUFFER_MAX_LEN_SEC 10
 
 //==============================================================================
@@ -70,7 +70,6 @@ private:
 
     double currentSampleRate = 44100;
 
-    int delayBufferLength = (int)currentSampleRate * BUFFER_MAX_LEN_SEC;
     //TODO: Buffer amount and echo amount are used to describe this same thing, make it more consistent
     int bufferAmount = 3;
     float delayLength = 1.0f;
@@ -81,7 +80,7 @@ private:
 
     float wetAmount = 1.0f;
 
-    void setDelayParams();
+    void setDelayBufferParams(int maxDelayBufferSize);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (DelayyyyyyAudioProcessor)
 };


### PR DESCRIPTION
Two commits:
- Remove magic number 10 and replace it with a define (should be changed into a variable in future)
- Optimize the sizes of the delay lines so that the shorter delays have shorter buffers (“Premature optimization is the root of all evil”)