### PR TITLE
Synced delay

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -32,33 +32,46 @@ DelayyyyyyAudioProcessorEditor::DelayyyyyyAudioProcessorEditor (DelayyyyyyAudioP
     addAndMakeVisible(&delayAmount);
     delayAttachment.reset(new SliderAttachment(*audioProcessor.getParameters(), "MAXDELAY", delayAmount));
 
-    /* Synced delay slider init (NOT ENABLED YET) */
-    /*delayAmountSynced.setSliderStyle(juce::Slider::LinearVertical);
-    delayAmountSynced.setRange(0.0, 16, 1.0);
-    delayAmountSynced.setTextBoxStyle(juce::Slider::TextBoxBelow, false, 60, 20);
-    delayAmountSynced.textFromValueFunction = [](double val) {
+    /* Synced delay slider init */
+    syncedDelayAmount.setSliderStyle(juce::Slider::LinearVertical);
+    syncedDelayAmount.setTextBoxStyle(juce::Slider::TextBoxBelow, false, 60, 20);
+
+    syncedDelayLabel.setText("Max delay", juce::dontSendNotification);
+    syncedDelayLabel.attachToComponent(&syncedDelayAmount, false);
+    syncedDelayLabel.setJustificationType(juce::Justification::centredBottom);
+
+    syncedDelayAmount.addListener(this);
+    addAndMakeVisible(&syncedDelayAmount);
+    syncedDelayAttachment.reset(new SliderAttachment(*audioProcessor.getParameters(), "SYNCEDMAXDELAY", syncedDelayAmount));
+
+    syncedDelayAmount.textFromValueFunction = [](double val) {
         switch ((int)val) {
         case 0:
-            return "1/64";
-        case 1:
             return "1/32";
-        case 2:
+        case 1:
             return "1/16";
-        case 3:
+        case 2:
             return "1/8";
-        case 4:
+        case 3:
             return "1/4";
-        case 5:
+        case 4:
             return "1/2";
-        case 6:
+        case 5:
             return "1";
+        case 6:
+            return "2";
+        case 7:
+            return "4";
+        case 8:
+            return "8";
+        case 9:
+            return "16";
         }
         return "";
     };
-    delayAmountSynced.setValue(1.0);*/
-
-    //delayAmountSynced.addListener(this);
-    //addChildComponent(&delayAmountSynced);
+    //Required here, because we change the textFromValueFunction after resetting the syncedDelayAttachment.
+    //It seems like reset also resets the syncedDelayAttachment, so these are done in a bit odd order
+    syncedDelayAmount.updateText();
 
     /* Echo amount slider init */
     echoAmount.setSliderStyle(juce::Slider::LinearVertical);
@@ -108,9 +121,11 @@ DelayyyyyyAudioProcessorEditor::DelayyyyyyAudioProcessorEditor (DelayyyyyyAudioP
     addAndMakeVisible(&wetAmount);
     wetAttachment.reset(new SliderAttachment(*audioProcessor.getParameters(), "WET", wetAmount));
 
-    /* BPM sync initialization (NOT ENABLED YET) */
-    //bpmSync.setButtonText("BPM Sync");
-    //addAndMakeVisible(&bpmSync);
+    /* BPM sync initialization */
+    bpmSync.setButtonText("BPM Sync");
+    addAndMakeVisible(&bpmSync);
+    bpmSync.addListener(this);
+    bpmSyncAttachment.reset(new ButtonAttachment(*audioProcessor.getParameters(), "BPMSYNC", bpmSync));
 }
 
 DelayyyyyyAudioProcessorEditor::~DelayyyyyyAudioProcessorEditor()
@@ -135,12 +150,30 @@ void DelayyyyyyAudioProcessorEditor::resized()
     fb.justifyContent = juce::FlexBox::JustifyContent::spaceBetween;
     fb.alignContent = juce::FlexBox::AlignContent::stretch;
 
-    fb.items.add(juce::FlexItem(delayAmount).withMinWidth(75.0f).withMinHeight(75.0f)
-                                            .withAlignSelf(juce::FlexItem::AlignSelf::stretch)
-                                            .withMargin(juce::FlexItem::Margin(topMarginSize, marginSize, marginSize, marginSize)));
-    fb.items.add(juce::FlexItem(echoAmount).withMinWidth(75.0f).withMinHeight(75.0f)
-                                           .withAlignSelf(juce::FlexItem::AlignSelf::stretch)
-                                           .withMargin(juce::FlexItem::Margin(topMarginSize, marginSize, marginSize, marginSize)));
+    juce::FlexBox delayBox;
+    delayBox.flexWrap = juce::FlexBox::Wrap::wrap;
+    delayBox.justifyContent = juce::FlexBox::JustifyContent::flexStart;
+    if (!bpmSync.getToggleState()) {
+        delayAmount.setVisible(true);
+        syncedDelayAmount.setVisible(false);
+        delayBox.items.add(juce::FlexItem(delayAmount).withMinWidth(75.0f).withMinHeight(200.0f));
+    }
+    else {
+        delayAmount.setVisible(false);
+        syncedDelayAmount.setVisible(true);
+        delayBox.items.add(juce::FlexItem(syncedDelayAmount).withMinWidth(75.0f).withMinHeight(200.0f));
+    }
+    delayBox.items.add(juce::FlexItem(bpmSync).withMinWidth(75.0f).withMinHeight(15.0f));
+    fb.items.add(juce::FlexItem(delayBox).withMinWidth(75.0f).withMargin(juce::FlexItem::Margin(topMarginSize, marginSize, marginSize, marginSize)));
+
+    juce::FlexBox echoBox;
+    echoBox.flexWrap = juce::FlexBox::Wrap::wrap;
+    echoBox.justifyContent = juce::FlexBox::JustifyContent::flexStart;
+    echoBox.items.add(juce::FlexItem(echoAmount).withMinWidth(75.0f).withMinHeight(200.0f));
+    //Add an empty item to level the bottom with the delay slider
+    echoBox.items.add(juce::FlexItem().withMinWidth(75.0f).withMinHeight(15.0f));
+
+    fb.items.add(juce::FlexItem(echoBox).withMinWidth(75.0f).withMargin(juce::FlexItem::Margin(topMarginSize, marginSize, marginSize, marginSize)));
     fb.items.add(juce::FlexItem(decayAmount).withMinWidth(75.0f).withMinHeight(75.0f)
                                             .withAlignSelf(juce::FlexItem::AlignSelf::flexStart)
                                             .withMargin(juce::FlexItem::Margin(topMarginSize, marginSize, marginSize, marginSize)));
@@ -156,7 +189,15 @@ void DelayyyyyyAudioProcessorEditor::resized()
 
 void DelayyyyyyAudioProcessorEditor::sliderValueChanged(juce::Slider* slider)
 {
-    if (slider == &delayAmount || slider == &echoAmount) {
+    if (slider == &delayAmount || slider == &syncedDelayAmount || slider == &echoAmount) {
         audioProcessor.setDelayBufferParams();
     }
+}
+
+void DelayyyyyyAudioProcessorEditor::buttonClicked(juce::Button* button)
+{
+    resized();
+    //TODO: This should be forced when the button has been clicked, because no value has changed
+    //Or add the bpmsyncstatus check to function
+    audioProcessor.setDelayBufferParams();
 }

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -197,7 +197,5 @@ void DelayyyyyyAudioProcessorEditor::sliderValueChanged(juce::Slider* slider)
 void DelayyyyyyAudioProcessorEditor::buttonClicked(juce::Button* button)
 {
     resized();
-    //TODO: This should be forced when the button has been clicked, because no value has changed
-    //Or add the bpmsyncstatus check to function
     audioProcessor.setDelayBufferParams();
 }

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -13,11 +13,12 @@
 #include "CustomSlider.h"
 
 typedef juce::AudioProcessorValueTreeState::SliderAttachment SliderAttachment;
+typedef juce::AudioProcessorValueTreeState::ButtonAttachment ButtonAttachment;
 
 //==============================================================================
 /**
 */
-class DelayyyyyyAudioProcessorEditor  : public juce::AudioProcessorEditor, private juce::Slider::Listener
+class DelayyyyyyAudioProcessorEditor  : public juce::AudioProcessorEditor, private juce::Slider::Listener, private juce::Button::Listener
 {
 public:
     DelayyyyyyAudioProcessorEditor (DelayyyyyyAudioProcessor&);
@@ -29,6 +30,7 @@ public:
 
 private:
     void sliderValueChanged(juce::Slider* slider) override;
+    void buttonClicked(juce::Button* button) override;
 
     // This reference is provided as a quick way for your editor to
     // access the processor object that created it.
@@ -37,7 +39,10 @@ private:
     CustomSlider delayAmount;
     juce::Label delayLabel;
     std::unique_ptr<SliderAttachment> delayAttachment;
-    juce::Slider delayAmountSynced;
+
+    CustomSlider syncedDelayAmount;
+    juce::Label syncedDelayLabel;
+    std::unique_ptr<SliderAttachment> syncedDelayAttachment;
 
     CustomSlider echoAmount;
     std::unique_ptr<SliderAttachment> echoAttachment;
@@ -55,6 +60,7 @@ private:
     std::unique_ptr<SliderAttachment> wetAttachment;
 
     juce::ToggleButton bpmSync;
+    std::unique_ptr<ButtonAttachment> bpmSyncAttachment;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (DelayyyyyyAudioProcessorEditor)
 };

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -161,13 +161,17 @@ float DelayyyyyyAudioProcessor::getSyncedDelay(int index) {
 }
 
 void DelayyyyyyAudioProcessor::setDelayBufferParams() {
-    if (*delayParameter == prevDelayValue && *echoParameter == prevEchoValue && *syncedDelayParameter == prevSyncedDelayValue) {
+    if (*delayParameter == prevDelayValue &&
+        *echoParameter == prevEchoValue &&
+        *syncedDelayParameter == prevSyncedDelayValue &&
+        *bpmSyncParameter == prevBpmSyncValue) {
         return;
     }
     else {
         prevDelayValue = *delayParameter;
         prevEchoValue = *echoParameter;
         prevSyncedDelayValue = *syncedDelayParameter;
+        prevBpmSyncValue = *bpmSyncParameter;
     }
 
     std::vector<DelayBuffer> newDelayBuffers;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -27,6 +27,11 @@ DelayyyyyyAudioProcessor::DelayyyyyyAudioProcessor()
                                                         "Max Delay",       // parameter name
                                                         juce::NormalisableRange<float>(0.0f, 5.0f, 0.001f, 0.5f, false), //NormalisableRange for adding skew
                                                         1.0f),             // default value
+            std::make_unique<juce::AudioParameterInt>("SYNCEDMAXDELAY",
+                                                      "Synced Max Delay",
+                                                      0,
+                                                      9,
+                                                      3),
             std::make_unique<juce::AudioParameterInt>("ECHOES",
                                                       "Echoes",
                                                       0,
@@ -47,13 +52,18 @@ DelayyyyyyAudioProcessor::DelayyyyyyAudioProcessor()
                                                         0.0f,
                                                         100.0f,
                                                         100.0f),
+            std::make_unique<juce::AudioParameterBool>("BPMSYNC",
+                                                       "BPM Sync",
+                                                       false),
         })
 {
     delayParameter = parameters.getRawParameterValue("MAXDELAY");
+    syncedDelayParameter = parameters.getRawParameterValue("SYNCEDMAXDELAY");
     echoParameter = parameters.getRawParameterValue("ECHOES");
     decayParameter = parameters.getRawParameterValue("DECAY");
     pingPongParameter = parameters.getRawParameterValue("PINGPONG");
     wetParameter = parameters.getRawParameterValue("WET");
+    bpmSyncParameter = parameters.getRawParameterValue("BPMSYNC");
 }
 
 DelayyyyyyAudioProcessor::~DelayyyyyyAudioProcessor()
@@ -122,25 +132,70 @@ void DelayyyyyyAudioProcessor::changeProgramName (int index, const juce::String&
 {
 }
 
+float DelayyyyyyAudioProcessor::getSyncedDelay(int index) {
+    switch (index) {
+    case 0:
+        return 1.0f/32.0f;
+    case 1:
+        return 1.0f/16.0f;
+    case 2:
+        return 1.0f/8.0f;
+    case 3:
+        return 1.0f/4.0f;
+    case 4:
+        return 1.0f/2.0f;
+    case 5:
+        return 1;
+    case 6:
+        return 2;
+    case 7:
+        return 4;
+    case 8:
+        return 8;
+    case 9:
+        return 16;
+    default:
+        return -1;
+
+    }
+}
+
 void DelayyyyyyAudioProcessor::setDelayBufferParams() {
-    if (*delayParameter == prevDelayValue && *echoParameter == prevEchoValue) {
+    if (*delayParameter == prevDelayValue && *echoParameter == prevEchoValue && *syncedDelayParameter == prevSyncedDelayValue) {
         return;
     }
     else {
         prevDelayValue = *delayParameter;
         prevEchoValue = *echoParameter;
+        prevSyncedDelayValue = *syncedDelayParameter;
     }
 
     std::vector<DelayBuffer> newDelayBuffers;
     int maxDelayBufferSize = (int)(BUFFER_MAX_LEN_SEC * currentSampleRate);
     for (int i = (int)*echoParameter - 1; i >= 0; i = i - 1) {
-        DelayBuffer newDelayBuffer;
-
         int divider = juce::jmax(1, 2 * i);
+        int delayInSamples = 0;
 
+        if (*bpmSyncParameter) {
+            //Magic number 60 comes from the amount of seconds in a minute
+            //Magic number 4 comes from the time signature 4/4
+            //Other time signatures are out of scope for this project (PRs welcome of course :))
+            float durationOfBar = 60.0f / bpm * 4.0f;
+
+            float syncedDelay = getSyncedDelay(*syncedDelayParameter - i);
+            if (syncedDelay != -1) {
+                delayInSamples = ((float)durationOfBar * (float)currentSampleRate) * syncedDelay;
+            }
+            else {
+                continue;
+            }
+        }
+        else {
+            delayInSamples = (int)(*delayParameter * currentSampleRate) / divider;
+        }
+        DelayBuffer newDelayBuffer;
+        //TODO: check if the size optimization makes sense in the BPM synced context
         newDelayBuffer.setDelayLineParameters(getTotalNumInputChannels(), maxDelayBufferSize / divider);
-
-        int delayInSamples = (int)(*delayParameter * currentSampleRate) / divider;
         newDelayBuffer.setDelayWritePosition(delayInSamples);
 
         newDelayBuffers.insert(newDelayBuffers.begin(), newDelayBuffer);

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -75,6 +75,7 @@ private:
     float prevDelayValue = -1.0f;
     float prevSyncedDelayValue = -1.0f;
     float prevEchoValue = -1.0f;
+    float prevBpmSyncValue = -1.0f;
 
     bool bpmSync = false;
     float bpm = 120.0f;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -11,11 +11,6 @@
 #include <JuceHeader.h>
 #include "DelayBuffer.h"
 
-//TODO: 10 seconds is a bit much, considering the fact the maximum unsynced delay time is 5 seconds (5 seconds defined in slider
-// should consider using a define for it as well). Perhaps this should  be variable, depending on the current maximum delay size?
-//TODO: How will this work with synced delay and slow BPM?
-#define BUFFER_MAX_LEN_SEC 10
-
 //==============================================================================
 /**
 */

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -13,6 +13,7 @@
 
 //TODO: 10 seconds is a bit much, considering the fact the maximum unsynced delay time is 5 seconds (5 seconds defined in slider
 // should consider using a define for it as well). Perhaps this should  be variable, depending on the current maximum delay size?
+//TODO: How will this work with synced delay and slow BPM?
 #define BUFFER_MAX_LEN_SEC 10
 
 //==============================================================================
@@ -54,6 +55,7 @@ public:
     const juce::String getProgramName (int index) override;
     void changeProgramName (int index, const juce::String& newName) override;
 
+    float getSyncedDelay(int index);
     void setDelayBufferParams();
 
     //==============================================================================
@@ -71,13 +73,19 @@ private:
     double currentSampleRate = 44100;
 
     float prevDelayValue = -1.0f;
+    float prevSyncedDelayValue = -1.0f;
     float prevEchoValue = -1.0f;
 
+    bool bpmSync = false;
+    float bpm = 120.0f;
+
     std::atomic<float>* delayParameter = nullptr;
+    std::atomic<float>* syncedDelayParameter = nullptr;
     std::atomic<float>* echoParameter = nullptr;
     std::atomic<float>* decayParameter = nullptr;
     std::atomic<float>* pingPongParameter = nullptr;
     std::atomic<float>* wetParameter = nullptr;
+    std::atomic<float>* bpmSyncParameter = nullptr;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (DelayyyyyyAudioProcessor)
 };


### PR DESCRIPTION
Add option for BPM synced delay.

Currently hardcoded to 120 BPM. This should be fixed in the future to get the host BPM from playhead, or allow user to set it manually if BPM can't be obtained from playhead