### PR TITLE
Revert "Set the initial values of parameters to default values"

### DIFF
--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -73,10 +73,10 @@ private:
     double currentSampleRate = 44100;
     bool isPlaying = false;
 
-    float prevDelayValue = 1.0f;
-    float prevSyncedDelayValue = 3.0f;
-    float prevEchoValue = 3.0f;
-    float prevBpmSyncValue = 0.0f;
+    float prevDelayValue = -1.0f;
+    float prevSyncedDelayValue = -1.0f;
+    float prevEchoValue = -1.0f;
+    float prevBpmSyncValue = -1.0f;
 
     //BPM behaves a bit differently, as it's value is fetched from playhead, not UI
     float nextBpmValue = 120.0f;


### PR DESCRIPTION
If the default values are already present, the plug-in doesn't make
sound before UI elements are changed as the delay buffers won't get
created before there is a change.

This reverts commit 8e329fa200dc6b5b135bcac47d7ceac2553c5ed8.